### PR TITLE
Revert "update for v2.1.1"

### DIFF
--- a/Formula/chain-maind.rb
+++ b/Formula/chain-maind.rb
@@ -1,24 +1,24 @@
 class ChainMaind < Formula
   desc "chain-main daemon"
   homepage "https://github.com/crypto-org-chain/chain-main"
-  version "2.1.1"
+  version "2.0.1"
   bottle :unneeded
 
   if OS.mac?
     if Hardware::CPU.arm?
-      url "https://github.com/crypto-org-chain/chain-main/releases/download/v2.1.1/chain-main_2.1.1_Darwin_arm64.tar.gz"
-      sha256 "3579f722dc3f8fb500f07171ade240c3916f73ed16bcfb2f76defef6bf952b45"
+      url "https://github.com/crypto-org-chain/chain-main/releases/download/v2.0.1/chain-main_2.0.1_Darwin_arm64.tar.gz"
+      sha256 "eb6274724eab1957a7b708a5a0887de9f213d053841fb58041f697e13728a454"
     elsif Hardware::CPU.intel?
-      url "https://github.com/crypto-org-chain/chain-main/releases/download/v2.1.1/chain-main_2.1.1_Darwin_x86_64.tar.gz"
-      sha256 "389de09548ffcd5cb55845c57e925537f60015bf3eb45f0c4d80b305c33049ee"
+      url "https://github.com/crypto-org-chain/chain-main/releases/download/v2.0.1/chain-main_2.0.1_Darwin_x86_64.tar.gz"
+      sha256 "a4d51bf98350c7ecbb5e6bab192c9cac2f4059754e5507d2a1970a8a5488c74a"
     end
   elsif OS.linux?
     if Hardware::CPU.arm?
-      url "https://github.com/crypto-org-chain/chain-main/releases/download/v2.1.1/chain-main_2.1.1_Linux_arm64.tar.gz"
-      sha256 "2e57ae0794e7cf7dc161b4a9c823ef6209247392540ef7114449f338e23ac57d"
+      url "https://github.com/crypto-org-chain/chain-main/releases/download/v2.0.1/chain-main_2.0.1_Linux_arm64.tar.gz"
+      sha256 "345c7eacfc768df355c3b3ecadc9cc39e3c1656c9c0c4d465b938834fa66ff03"
     else
-      url "https://github.com/crypto-org-chain/chain-main/releases/download/v2.1.1/chain-main_2.1.1_Linux_x86_64.tar.gz"
-      sha256 "92b4035512bbcceaa8913461e6f41418379aee05670af5179f20928e26b3bced"
+      url "https://github.com/crypto-org-chain/chain-main/releases/download/v2.0.1/chain-main_2.0.1_Linux_x86_64.tar.gz"
+      sha256 "5e9e9f703cb85c72573086e384e187e752463b2ed0ccd612094a1f29a13f0158"
     end
   end
 

--- a/README.md
+++ b/README.md
@@ -33,5 +33,5 @@ $ brew install chain-maind@1.2.1
 
 ```bash
 $ chain-maind version
-2.1.1
+2.0.1
 ```


### PR DESCRIPTION
Reverts `crypto-org-chain/homebrew-chain-maind#18` - put it back to the stable version `v2.0.1`