### PR TITLE
Brew tap fix

### DIFF
--- a/Formula/chain-maind.rb
+++ b/Formula/chain-maind.rb
@@ -2,7 +2,6 @@ class ChainMaind < Formula
   desc "chain-main daemon"
   homepage "https://github.com/crypto-org-chain/chain-main"
   version "3.3.2"
-  bottle :unneeded
 
   if OS.mac?
     if Hardware::CPU.arm?

--- a/Formula/chain-maind@1.2.1.rb
+++ b/Formula/chain-maind@1.2.1.rb
@@ -2,7 +2,6 @@ class ChainMaindAT121 < Formula
   desc "chain-main daemon"
   homepage "https://github.com/crypto-org-chain/chain-main"
   version "1.2.1"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/crypto-org-chain/chain-main/releases/download/v1.2.1/chain-main_1.2.1_Darwin_x86_64.tar.gz"

--- a/Formula/chain-maind@2.0.1.rb
+++ b/Formula/chain-maind@2.0.1.rb
@@ -1,8 +1,7 @@
-class ChainMaind < Formula
+class ChainMaindAT201 < Formula
   desc "chain-main daemon"
   homepage "https://github.com/crypto-org-chain/chain-main"
   version "2.0.1"
-  bottle :unneeded
 
   if OS.mac?
     if Hardware::CPU.arm?


### PR DESCRIPTION
Removed the deprecated bottle :unneeded call.

Updated chain-maind@2.0.1 to use the correct class name.